### PR TITLE
Update the archive filter api usage, and authentication backend

### DIFF
--- a/download_data.py
+++ b/download_data.py
@@ -58,10 +58,10 @@ def download_frames(sdate, edate, headers, prop, datafolder):
     ndownloaded = 0
     response = requests.get('https://archive-api.lco.global/frames/?' +
                             'limit=50&' +
-                            'RLEVEL=91&' +
+                            'reduction_level=91&' +
                             'start='+sdate+'&' +
                             'end='+edate+'&' +
-                            'PROPID=' + prop,
+                            'proposal_id=' + prop,
                             headers=headers).json()
 
     frames = response['results']
@@ -110,8 +110,8 @@ def get_headers_from_token(username, password):
       Returns:
           dict: LCO authentication token
     """
-    # Get LCOGT token:
-    response = requests.post('https://archive-api.lco.global/api-token-auth/',
+    # Get LCOGT token from the Observation Portal:
+    response = requests.post('https://observe.lco.global/api/api-token-auth/',
                              data={'username': username,
                                    'password': password}
                              ).json()


### PR DESCRIPTION
We've updated the archive project and changed the names of some fields and filters to be more generic (i.e. reduction_level instead of RLEVEL). We've also updated the project to be able to use LCO's Observation Portal api_token for authentication. The application is still currently backwards compatible with the previous api, filters, and authentication method, but we will be deprecating that in the future.

This PR should address all the necessary changes - let me know if you have any questions